### PR TITLE
Fix npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,13 +2,10 @@ SabreDAV/
 
 /*.zip
 /coverage/
-/HISTORY.md
 /Makefile
-/README.md
 /.git
 /.gitignore
 /.jshintrc
 /.travis.yml
-/lib
 /node_modules
 /test

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "davinci.js",
-  "version": "0.9.1",
+  "name": "davincijs",
+  "version": "0.9.2",
   "author": "Gareth Aye [:gaye] <gaye@mozilla.com>",
   "description": "Javascript CalDAV client library (rfc 4791, rfc 5545)",
   "license": "MPL-2.0",
-  "main": "davinci.js",
+  "main": "./lib/index",
 
   "keywords": [
     "calendar",


### PR DESCRIPTION
This patch
1. publishes code in lib/ to npm
2. changes the npm name to davincijs from davinci.js
3. changes the package.json main field to point to lib/index
