### PR TITLE
Enable sync support on a calendar

### DIFF
--- a/test/integration/server/bootstrap.js
+++ b/test/integration/server/bootstrap.js
@@ -12,7 +12,8 @@ var data = {
   uri: 'default',
   description: 'administrator calendar',
   components: 'VEVENT,VTODO',
-  transparent: '0'
+  transparent: '0',
+  synctoken: '1'
 };
 
 var columns = [],


### PR DESCRIPTION
When a calendar backend returns an empty value for the current sync-token, this instructs the sync plugin that sync-collection is not supported on that resource.

This correctly creates the calendar. We just needed to initialize the synctoken with a value.
