### PR TITLE
Experiment with request factory pattern

### DIFF
--- a/lib/request/address_book_query.js
+++ b/lib/request/address_book_query.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Request = require('./request'),
-    debug = require('debug')('dav:request:address_book_query'),
     parser = require('../parser'),
     template = require('../template'),
     util = require('./util');
@@ -10,30 +9,58 @@ var Request = require('./request'),
  * Options:
  *
  *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) props - list of props to request.
+ *   (Array.<Prop>) props - list of props to request.
  *   (String) url - endpoint to request.
  */
-module.exports = function(options) {
-  debug('Will send request ' + JSON.stringify(options));
+function AddressBookQuery(options) {
+  this.transformRequest = this.transformRequest.bind(this);
+  this.transformResponse = this.transformResponse.bind(this);
 
-  var requestData = template.addressBookQuery({ props: options.props || [] });
-
-  function transformRequest(xhr) {
-    util.setRequestHeaders(xhr, options);
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
   }
+}
+module.exports = AddressBookQuery;
 
-  function transformResponse(xhr) {
+AddressBookQuery.prototype = {
+  /**
+   * @type {String}
+   */
+  depth: null,
+
+  /**
+   * @type {Array.<Prop>}
+   */
+  props: null,
+
+  /**
+   * @type {String}
+   */
+  url: null,
+
+  transformRequest: function(xhr) {
+    util.setRequestHeaders(xhr, options);
+  },
+
+  transformResponse: function(xhr) {
     var multistatus = parser.multistatus(xhr.responseText);
     return multistatus.response.map(function(response) {
       return { href: response.href, props: util.getProps(response.propstat) };
     });
-  }
+  },
 
-  return new Request({
-    method: 'REPORT',
-    url: options.url,
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    return new Request({
+      method: 'REPORT',
+      url: this.url,
+      requestData: template.addressBookQuery({ props: this.props }),
+      transformRequest: this.transformRequest,
+      transformResponse: this.transformResponse
+    });
+  }
 };

--- a/lib/request/basic.js
+++ b/lib/request/basic.js
@@ -11,22 +11,58 @@ var Request = require('./request'),
  *   (String) etag - cached calendar object etag.
  *   (String) url - endpoint to request.
  */
-module.exports = function(options) {
-  function transformRequest(xhr) {
-    util.setRequestHeaders(xhr, options);
-  }
+function Basic(options) {
+  this.transformRequest = this.transformRequest.bind(this);
+  this.transformResponse = this.transformResponse.bind(this);
 
-  function transformResponse(xhr) {
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
+  }
+}
+
+Basic.prototype = {
+  /**
+   * @type {String}
+   */
+  data: null,
+
+  /**
+   * @type {String}
+   */
+  method: null,
+
+  /**
+   * @type {String}
+   */
+  etag: null,
+
+  /**
+   * @type {String}
+   */
+  url: null,
+
+  transformRequest: function(xhr) {
+    util.setRequestHeaders(xhr, this);
+  },
+
+  transformResponse: function(xhr) {
     if (xhr.status < 200 || xhr.status > 300) {
       throw new Error('Bad status: ' + xhr.status);
     }
-  }
+  },
 
-  return new Request({
-    method: options.method,
-    url: options.url,
-    requestData: options.data,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    return new Request({
+      method: this.method,
+      url: this.url,
+      requestData: this.data,
+      transformRequest: this.transformRequest,
+      transformResponse: this.transformResponse
+    });
+  }
 };

--- a/lib/request/caldav_filter.js
+++ b/lib/request/caldav_filter.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * @param {String} type - one of 'comp-filter' or 'time-filter'.
+ * @param {Object} attrs - map from attribute names to values.
+ * @param {Array.<CaldavFilter>} children - sub filters.
+ */
+function CaldavFilter(type, attrs, children) {
+  this.type = type;
+  this.attrs = attrs;
+  this.children = children || [];
+}
+module.exports = CaldavFilter;

--- a/lib/request/calendar_query.js
+++ b/lib/request/calendar_query.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Request = require('./request'),
-    debug = require('debug')('dav:request:calendar_query'),
     parser = require('../parser'),
     template = require('../template'),
     util = require('./util');
@@ -10,36 +9,76 @@ var Request = require('./request'),
  * Options:
  *
  *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) filters - list of filters to send with request.
- *   (Array.<Object>) props - list of props to request.
+ *   (Array.<CaldavFilter>) filters - list of filters to send with request.
+ *   (Array.<Prop>) props - list of props to request.
  *   (String) timezone - VTIMEZONE calendar object.
  *   (String) url - endpoint to request.
  */
-module.exports = function(options) {
-  debug('Will send request ' + JSON.stringify(options));
+function CalendarQuery(options) {
+  this.transformRequest = this.transformRequest.bind(this);
+  this.transformResponse = this.transformResponse.bind(this);
 
-  var requestData = template.calendarQuery({
-    props: options.props || [],
-    filters: options.filters || [],
-    timezone: options.timezone
-  });
-
-  function transformRequest(xhr) {
-    util.setRequestHeaders(xhr, options);
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
   }
+}
+module.exports = CalendarQuery;
 
-  function transformResponse(xhr) {
+CalendarQuery.prototype = {
+  /**
+   * @type {String}
+   */
+  depth: null,
+
+  /**
+   * @type {Array.<CaldavFilter>}
+   */
+  filters: null,
+
+  /**
+   * @type {Array.<Prop>}
+   */
+  props: null,
+
+  /**
+   * @type {String}
+   */
+  timezone: null,
+
+  /**
+   * @type {String}
+   */
+  url: null,
+
+  transformRequest: function(xhr) {
+    util.setRequestHeaders(xhr, this);
+  },
+
+  transformResponse: function(xhr) {
     var multistatus = parser.multistatus(xhr.responseText);
     return multistatus.response.map(function(response) {
       return { href: response.href, props: util.getProps(response.propstat) };
     });
-  }
+  },
 
-  return new Request({
-    method: 'REPORT',
-    url: options.url,
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    var data = template.calendarQuery({
+      props: this.props,
+      filters: this.filters,
+      timezone: this.timezone
+    });
+
+    return new Request({
+      method: 'REPORT',
+      url: options.url,
+      requestData: data,
+      transformRequest: this.transformRequest,
+      transformResponse: this.transformResponse
+    });
+  }
 };

--- a/lib/request/discovery.js
+++ b/lib/request/discovery.js
@@ -14,20 +14,39 @@ var Request = require('./request'),
  *   (String) bootstrap - one of 'caldav' or 'carddav'. Defaults to 'caldav'.
  *   (String) server - url for calendar server.
  */
-module.exports = function(options) {
-  var endpoint = url.parse(options.server),
-      protocol = endpoint.protocol || 'http:',
-      bootstrap = options.bootstrap || 'caldav';
+function Discovery(options) {
+  this.transformResponse = this.transformResponse.bind(this);
+  this.onerror = this.onerror.bind(this);
 
-  var uri = format(
-    '%s//%s/.well-known/%s',
-    protocol,
-    endpoint.host,
-    bootstrap
-  );
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
+  }
 
-  function transformResponse(xhr) {
-    if (xhr.status >= 200 && xhr.status <= 400) {
+  this.endpoint = url.parse(this.server);
+}
+module.exports = Discovery;
+
+Discovery.prototype = {
+  /**
+   * @type {String}
+   */
+  bootstrap: null,
+
+  /**
+   * @type {String}
+   */
+  endpoint: null,
+
+  /**
+   * @type {String}
+   */
+  server: null,
+
+  transformResponse: function(xhr) {
+    var endpoint = this.endpoint;
+    if (xhr.status >= 300 && xhr.status <= 400) {
       var location = xhr.getResponseHeader('Location');
       if (typeof location === 'string' && location.length) {
         debug('Discovery redirected to ' + location);
@@ -41,18 +60,34 @@ module.exports = function(options) {
     }
 
     return endpoint.href;
-  }
+  },
 
-  function onerror(error) {
+  onerror: function(error) {
     // That didn't go so well now did it?
     debug('Discovery failed with error ' + error);
     return endpoint.href;
-  }
+  },
 
-  return new Request({
-    method: 'GET',
-    url: uri,
-    transformResponse: transformResponse,
-    onerror: onerror
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    var endpoint = this.endpoint,
+        protocol = endpoint.protocol || 'http:',
+        bootstrap = this.bootstrap || 'caldav';
+
+    this.uri = format(
+      '%s//%s/.well-known/%s',
+      protocol,
+      endpoint.host,
+      bootstrap
+    );
+
+    return new Request({
+      method: 'GET',
+      url: uri,
+      transformResponse: this.transformResponse,
+      onerror: this.onerror
+    });
+  }
 };

--- a/lib/request/index.js
+++ b/lib/request/index.js
@@ -1,7 +1,16 @@
+/**
+ * model
+ */
+exports.CaldavFilter = require('./caldav_filter');
+exports.Prop = require('./prop');
+
+/**
+ * request
+ */
+exports.AddressBookQuery = require('./address_book_query');
+exports.Basic = require('./basic');
+exports.CalendarQuery = require('./calendar_query');
+exports.Discovery = require('./discovery');
+exports.Propfind = require('./propfind');
 exports.Request = require('./request');
-exports.addressBookQuery = require('./address_book_query');
-exports.basic = require('./basic');
-exports.calendarQuery = require('./calendar_query');
-exports.discovery = require('./discovery');
-exports.propfind = require('./propfind');
-exports.syncCollection = require('./sync_collection');
+exports.SyncCollection = require('./sync_collection');

--- a/lib/request/prop.js
+++ b/lib/request/prop.js
@@ -1,0 +1,11 @@
+'use strict';
+
+/**
+ * @param {String} namespace - xmlns for prop.
+ * @param {String} localName - name of prop.
+ */
+function Prop(namespace, localName) {
+  this.namespace = namespace;
+  this.localName = localName;
+};
+module.exports = prop;

--- a/lib/request/propfind.js
+++ b/lib/request/propfind.js
@@ -9,17 +9,49 @@ var Request = require('./request'),
  * Options:
  *
  *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) props - list of props to request.
+ *   (Boolean) mergeResponses - whether or not to merge multistatus responses.
+ *   (Array.<Prop>) props - list of props to request.
  *   (String) url - endpoint to request.
  */
-module.exports = function(options) {
-  var requestData = template.propfind({ props: options.props });
+function Propfind(options) {
+  this.transformRequest = this.transformRequest.bind(this);
+  this.transformResponse = this.transformResponse.bind(this);
 
-  function transformRequest(xhr) {
-    util.setRequestHeaders(xhr, options);
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
   }
+}
+exports.Propfind = Propfind;
 
-  function transformResponse(xhr) {
+Propfind.prototype = {
+  /**
+   * One of '0', '1', or 'Infinity'.
+   * @type {String}
+   */
+  depth: null,
+
+  /**
+   * @type {Boolean}
+   */
+  mergeResponses: null,
+
+  /**
+   * @type {Array.<Prop>}
+   */
+  props: null,
+
+  /**
+   * @type {String}
+   */
+  url: null,
+
+  transformRequest: function(xhr) {
+    util.setRequestHeaders(xhr, this);
+  },
+
+  transformResponse: function(xhr) {
     var multistatus = parser.multistatus(xhr.responseText);
     var responses = multistatus.response.map(function(response) {
       return {
@@ -44,13 +76,18 @@ module.exports = function(options) {
     });
 
     return { props: merged, hrefs: hrefs };
-  }
+  },
 
-  return new Request({
-    method: 'PROPFIND',
-    url: options.url,
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    return new Request({
+      method: 'PROPFIND',
+      url: this.url,
+      requestData: template.propfind({ props: this.props }),
+      transformRequest: this.transformRequest,
+      transformResponse: this.transformResponse
+    });
+  }
 };

--- a/lib/request/sync_collection.js
+++ b/lib/request/sync_collection.js
@@ -9,36 +9,78 @@ var Request = require('./request'),
  * Options:
  *
  *   (String) depth - option value for Depth header.
- *   (Array.<Object>) props - list of props to request.
+ *   (Array.<Prop>) props - list of props to request.
  *   (Number) syncLevel - indicates scope of the sync report request.
  *   (String) syncToken - synchronization token provided by the server.
  *   (String) url - endpoint to request.
  */
-module.exports = function(options) {
-  var requestData = template.syncCollection({
-    props: options.props,
-    syncLevel: options.syncLevel,
-    syncToken: options.syncToken
-  });
+function SyncCollection(options) {
+  this.transformRequest = this.transformRequest.bind(this);
+  this.transformResponse = this.transformResponse.bind(this);
 
-  function transformRequest(xhr) {
-    util.setRequestHeaders(xhr, options);
+  if (typeof options === 'object') {
+    for (var key in options) {
+      this[key] = options[key];
+    }
   }
+}
+module.exports = SyncCollection;
 
-  function transformResponse(xhr) {
+SyncCollection.prototype = {
+  /**
+   * @type {String}
+   */
+  depth: null,
+
+  /**
+   * @type {Array.<Prop>}
+   */
+  props: null,
+
+  /**
+   * @type {Number}
+   */
+  syncLevel: null,
+
+  /**
+   * @type {String}
+   */
+  syncToken: null,
+
+  /**
+   * @type {String}
+   */
+  url: null,
+
+  transformRequest: function(xhr) {
+    util.setRequestHeaders(xhr, options);
+  },
+
+  transformResponse: function(xhr) {
     var multistatus = parser.multistatus(xhr.responseText);
     var responses = multistatus.response.map(function(response) {
       return { href: response.href, props: util.getProps(response.propstat) };
     });
 
     return { responses: responses, syncToken: multistatus.syncToken };
-  }
+  },
 
-  return new Request({
-    method: 'REPORT',
-    url: options.url,
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
+  /**
+   * @return {dav.request.Request} request object.
+   */
+  createRequest: function() {
+    var data = template.syncCollection({
+      props: options.props,
+      syncLevel: options.syncLevel,
+      syncToken: options.syncToken
+    });
+
+    return new Request({
+      method: 'REPORT',
+      url: this.url,
+      requestData: data,
+      transformRequest: this.transformRequest,
+      transformResponse: this.transformResponse
+    });
+  }
 };


### PR DESCRIPTION
Hey @evert! This is a wip/experiment to see what things would look like if I took one of the routes that you suggested related to having things like `Propfind` be request factories which you can configure and then ask for `Request` objects. Let me know what you think. This would enable

``` js
var xhr = new dav.transport.Basic(
  new dav.Credentials({
    username: 'xxx',
    password: 'xxx'
  })
);

var client = new dav.Client(xhr);

// Create PROPFIND
var propfind = new dav.Propfind({
  depth: 'Infinity',
  url: 'http://dav.example.com'
});
propfind.props.push(
  new dav.Prop({ namespace: ns.CALDAV, name: 'getctag' })
);

// Send request
var request = propfind.createRequest();
var promise = client.send(request);

// Or perhaps
var promise = client.send(propfind);  // calls createRequest() on propfind internally

promise.then(function(response) {
  console.log(response.props.getctag);
});
```
