### PR TITLE
Fix SabreDAV URL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,5 @@ test/integration/server/SabreDAV: SabreDAV
 	cd test/integration/server/SabreDAV && cp ../calendarserver.php calendarserver.php
 
 SabreDAV:
-	wget -O $(SABRE_DAV_ZIPBALL) https://github.com/fruux/sabre-dav/releases/download/$(SABRE_DAV_VERSION)/$(SABRE_DAV_ZIPBALL)
+	wget -O $(SABRE_DAV_ZIPBALL) https://github.com/sabre-io/dav/releases/download/$(SABRE_DAV_VERSION)/$(SABRE_DAV_ZIPBALL)
 	unzip -q $(SABRE_DAV_ZIPBALL)


### PR DESCRIPTION
Hello @lambdabaa,

this PR updates the changed SabreDAV project URL to:
https://github.com/sabre-io/dav

It allows to run the integration tests again.

Thanks, Georgy