### PR TITLE
options.loadObjects dependent depth (verification advisable)

### DIFF
--- a/lib/webdav.js
+++ b/lib/webdav.js
@@ -53,7 +53,9 @@ export let supportedReportSet = co.wrap(function *(collection, options) {
   debug('Checking supported report set for collection at ' + collection.url);
   var req = request.propfind({
     props: [ { name: 'supported-report-set', namespace: ns.DAV } ],
-    depth: 1,
+    // AH20190109 - In my opinion 'depth' should be dependent on 'options.loadObjects'?!
+    //            - "options.loadObjects === undefined" for backward compatibility with "depth: 1".  
+    depth: (options.loadObjects === undefined || options.loadObjects ? 1 : 0),
     mergeResponses: true
   });
 


### PR DESCRIPTION
I tried to get a quick retrieve of the available address books via
dav.createAccount({accountType : 'carddav', loadCollections: true,
loadObjects: false}), but it wasn't "quick"!
After some debugging I recognized that I also retrieved a list of all
contacts (some hundreds), beside the expected address books.
I'm not very familiar with WebDAV and also not an RFC extraterrestrial,
but after some reading I interpreted the specs in that way that I only
have to expect the contacts when loadObject = true.
This is what this fix does and now the address book query is quick.