### PR TITLE
test(caldav): multiple props in calendarQuery

### DIFF
--- a/test/unit/request/calendar_query_test.js
+++ b/test/unit/request/calendar_query_test.js
@@ -31,7 +31,7 @@ suite('request.calendarQuery', function() {
     yield mock.verify(send);
   }));
 
-  test('should add specified props to report body', co.wrap(function *() {
+  test('should add single prop to report body', co.wrap(function *() {
     let mock = nockWrapper('http://127.0.0.1:1337')
       .matchRequestBody('/principals/admin/', 'REPORT', body => {
         return body.indexOf('<d:catdog />') !== -1;
@@ -39,6 +39,23 @@ suite('request.calendarQuery', function() {
 
     let req = calendarQuery({
       props: [ { name: 'catdog', namespace: ns.DAV } ]
+    });
+
+    let send = xhr.send(req, 'http://127.0.0.1:1337/principals/admin/');
+    yield mock.verify(send);
+  }));
+
+  test('should add multiple props to report body', co.wrap(function *() {
+    let mock = nockWrapper('http://127.0.0.1:1337')
+      .matchRequestBody('/principals/admin/', 'REPORT', body => {
+        return body.indexOf('<d:catdog /><d:winslow />') === -1;
+      });
+
+    let req = calendarQuery({
+      props: [
+        { name: 'catdog', namespace: ns.DAV },
+        { name: 'winslow', namespace: ns.DAV },
+      ]
     });
 
     let send = xhr.send(req, 'http://127.0.0.1:1337/principals/admin/');


### PR DESCRIPTION
The buggy behaviour when passing multiple props is that they get mapped
to the final XML string with a `,` separator.

⚠️ This is a bug-report-in-form-of-a-test rather than a direct contribution.

## Example

I have been mucking about with the low-level API for no good reason and tried to use `dav.request.calendarQuery` (and by extension `dav.template.caledarQuery`?) with invalid results.

```javascript
dav = require('dav')

xhr = new dav.transport.Transport(new dav.Credentials())
client = new dav.Client(xhr)
req = dav.request.calendarQuery({
  props: [
    { name: 'catdog', namespace: dav.ns.DAV },
    { name: 'winslow', namespace: dav.ns.CALDAV },
  ],
})
client.send(req, 'https://example.org/remote.php/dav/calendars/user/calname')
```

## Observed Results

The sent XML is invalid due to a comma:

```xml
    <d:prop>
      <d:catdog />,<c:winslow />
    </d:prop>
```

## Expected Results

The XML should not contain a comma between the props:
```xml
    <d:prop>
      <d:catdog /><c:winslow />
    </d:prop>
```

## More Info
The endpoint in question is an ownCloud instance which is why I'm even trying to do it via low-level code 🙄.

I didn't figure out a proper fix but hope that the included test will help narrow down the issue for someone better versed in the code base.